### PR TITLE
object-fit property to contain to prevent avatar stretching.

### DIFF
--- a/src/components/Avatar.svelte
+++ b/src/components/Avatar.svelte
@@ -66,6 +66,7 @@
 		height: var(--size);
 		width: var(--size);
 		background-color: var(--color-button-bg);
+		object-fit: contain;
 
 		&--size {
 			&-xs {


### PR DESCRIPTION
The current website contains the avatar within the box as seen here https://modrinth.com/mod/smartvision but the rewrite does not https://rewrite.modrinth.com/mod/smartvision