### PR TITLE
Copy Knossos parser changes to Omorphia

### DIFF
--- a/lib/helpers/parse.js
+++ b/lib/helpers/parse.js
@@ -14,14 +14,17 @@ export const configuredXss = new xss.FilterXSS({
     kbd: ['id'],
     input: ['checked', 'disabled', 'type'],
     iframe: ['width', 'height', 'allowfullscreen', 'frameborder', 'start', 'end'],
-    img: [...xss.whiteList.img, 'usemap'],
+    img: [...xss.whiteList.img, 'usemap', 'style'],
     map: ['name'],
     area: [...xss.whiteList.a, 'coords'],
     a: [...xss.whiteList.a, 'rel'],
+    td: [...xss.whiteList.td, 'style'],
+    th: [...xss.whiteList.th, 'style'],
   },
   css: {
     whiteList: {
       'image-rendering': /^pixelated$/,
+      'text-align': /^center|left|right$/,
     },
   },
   onIgnoreTagAttr: (tag, name, value) => {
@@ -50,12 +53,14 @@ export const configuredXss = new xss.FilterXSS({
     }
 
     // For Highlight.JS
-    if (
-      name === 'class' &&
-      ['pre', 'code', 'span'].includes(tag) &&
-      (value.startsWith('hljs-') || value.startsWith('language-'))
-    ) {
-      return name + '="' + xss.escapeAttrValue(value) + '"'
+    if (name === 'class' && ['pre', 'code', 'span'].includes(tag)) {
+      const allowedClasses = []
+      for (const className of value.split(/\s/g)) {
+        if (className.startsWith('hljs-') || className.startsWith('language-')) {
+          allowedClasses.push(className)
+        }
+      }
+      return name + '="' + xss.escapeAttrValue(allowedClasses.join(' ')) + '"'
     }
   },
   safeAttrValue(tag, name, value, cssFilter) {


### PR DESCRIPTION
This PR changes the XSS parser to be the same as Knossos, as right now they are separated but need to match for the launcher and website to have the same markdown parsing, in the future Knossos should be switched to using Omorphia for at least the markdown parsing so such PRs is not needed.

This copies over these PRs:
https://github.com/modrinth/knossos/pull/1174
https://github.com/modrinth/knossos/pull/1176

This will also fix this issue:
https://github.com/modrinth/theseus/issues/231