### PR TITLE
small dropdown menu

### DIFF
--- a/docs/components/dropdown-button.md
+++ b/docs/components/dropdown-button.md
@@ -27,6 +27,7 @@
     default-value="delete"
     name="dropdown-two"
     render-up
+    small
   >
     <template #delete>
       <TrashIcon /> Delete
@@ -98,6 +99,7 @@
   @option-click="handleOptionClick"
   color="primary"
   render-up
+  small
 >
   <template #delete>
     <TrashIcon /> Delete

--- a/docs/components/dropdown-button.md
+++ b/docs/components/dropdown-button.md
@@ -27,7 +27,6 @@
     default-value="delete"
     name="dropdown-two"
     render-up
-    small
   >
     <template #delete>
       <TrashIcon /> Delete
@@ -73,6 +72,52 @@
     name="dropdown-four"
     render-up
     disabled
+  >
+    <template #delete>
+      <TrashIcon /> Delete
+    </template>
+    <template #save>
+      <CheckIcon /> Save
+    </template>
+    <template #recycle>
+      <UpdatedIcon /> Recycle
+    </template>
+    <template #reduce>
+      <ChevronDownIcon /> Reduce
+    </template>
+    <template #reuse>
+      <CalendarIcon /> Reuse
+    </template>
+  </DropdownButton>
+  <DropdownButton
+    :options="['delete', 'save', 'recycle', 'reduce', 'reuse']"
+    default-value="delete"
+    name="dropdown-one"
+    color="primary"
+    small
+  >
+    <template #delete>
+      <TrashIcon /> Delete
+    </template>
+    <template #save>
+      <CheckIcon /> Save
+    </template>
+    <template #recycle>
+      <UpdatedIcon /> Recycle
+    </template>
+    <template #reduce>
+      <ChevronDownIcon /> Reduce
+    </template>
+    <template #reuse>
+      <TransferIcon /> Reuse
+    </template>
+  </DropdownButton>
+  <DropdownButton
+    :options="['delete', 'save', 'recycle', 'reduce', 'reuse']"
+    default-value="delete"
+    name="dropdown-two"
+    render-up
+    small
   >
     <template #delete>
       <TrashIcon /> Delete

--- a/docs/components/dropdown-select.md
+++ b/docs/components/dropdown-select.md
@@ -19,7 +19,6 @@ const options = ref([{ test: 'hello', display: 'no' }, { test: 'nob', display: '
     :options="['Daily', 'Weekly', 'Monthly', 'Tomorrow', 'Yesterday', 'Today', 'Biweekly', 'Tuesday', 'January']"
     placeholder="Choose Frequency"
     render-up
-    small
   />
   <DropdownSelect
     v-model="value"
@@ -32,6 +31,19 @@ const options = ref([{ test: 'hello', display: 'no' }, { test: 'nob', display: '
     :options="options"
     placeholder="Choose Frequency"
     :display-name="(name) => name?.display"
+  />
+  <DropdownSelect
+    v-model="value"
+    :options="['Daily', 'Weekly', 'Monthly', 'Tomorrow', 'Yesterday', 'Today', 'Biweekly', 'Tuesday', 'January']"
+    placeholder="Choose Frequency"
+    small
+  />
+  <DropdownSelect
+    v-model="value"
+    :options="['Daily', 'Weekly', 'Monthly', 'Tomorrow', 'Yesterday', 'Today', 'Biweekly', 'Tuesday', 'January']"
+    placeholder="Choose Frequency"
+    render-up
+    small
   />
 </DemoContainer>
 

--- a/docs/components/dropdown-select.md
+++ b/docs/components/dropdown-select.md
@@ -19,6 +19,7 @@ const options = ref([{ test: 'hello', display: 'no' }, { test: 'nob', display: '
     :options="['Daily', 'Weekly', 'Monthly', 'Tomorrow', 'Yesterday', 'Today', 'Biweekly', 'Tuesday', 'January']"
     placeholder="Choose Frequency"
     render-up
+    small
   />
   <DropdownSelect
     v-model="value"
@@ -40,5 +41,6 @@ const options = ref([{ test: 'hello', display: 'no' }, { test: 'nob', display: '
   :options="['Daily', 'Weekly', 'Monthly', 'Tomorrow', 'Yesterday', 'Today', 'Biweekly', 'Tuesday', 'January']"
   placeholder="Choose Frequency"
   render-up
+  small
 />
 ```

--- a/lib/components/base/DropdownButton.vue
+++ b/lib/components/base/DropdownButton.vue
@@ -39,7 +39,7 @@
           v-show="dropdownVisible"
           class="options"
           role="listbox"
-          :class="{ down: !renderUp, up: renderUp }"
+          :class="{ down: !renderUp, up: renderUp, small: small }"
         >
           <div
             v-for="(option, index) in options"
@@ -102,6 +102,10 @@ const props = defineProps({
   color: {
     type: String,
     default: '',
+  },
+  small: {
+    type: Boolean,
+    default: false,
   },
 })
 

--- a/lib/components/base/DropdownButton.vue
+++ b/lib/components/base/DropdownButton.vue
@@ -238,6 +238,10 @@ onBeforeUnmount(() => {
     overflow-y: auto;
     box-shadow: var(--shadow-inset-sm), 0 0 0 0 transparent;
 
+    &.small {
+      max-height: 9.375rem !important;
+    }
+
     .option {
       background-color: var(--color-button-bg);
       display: flex;

--- a/lib/components/base/DropdownSelect.vue
+++ b/lib/components/base/DropdownSelect.vue
@@ -31,7 +31,7 @@
           v-show="dropdownVisible"
           class="options"
           role="listbox"
-          :class="{ down: !renderUp, up: renderUp }"
+          :class="{ down: !renderUp, up: renderUp, small: small }"
         >
           <div
             v-for="(option, index) in options"
@@ -95,6 +95,10 @@ const props = defineProps({
   displayName: {
     type: Function,
     default: (option) => option,
+  },
+  small: {
+    type: Boolean,
+    default: false,
   },
 })
 

--- a/lib/components/base/DropdownSelect.vue
+++ b/lib/components/base/DropdownSelect.vue
@@ -249,6 +249,10 @@ const isChildOfDropdown = (element) => {
     overflow-y: auto;
     box-shadow: var(--shadow-inset-sm), 0 0 0 0 transparent;
 
+    &.small {
+      max-height: 9.375rem !important;
+    }
+  
     .option {
       background-color: var(--color-button-bg);
       display: flex;


### PR DESCRIPTION
This can prevent unwanted overflow issues, but can also be handy for specific dropdown menu's that needs to be smaller.

Overflow issue:
![image](https://github.com/modrinth/omorphia/assets/20028486/f8e89e68-ca99-4034-8e00-90263699c793)
> _**note:** this can also be changed in the launcher but i preferred this option, in my opinion a smaller dropdown looks better in this situation_


After adding `small`:
![image](https://github.com/modrinth/omorphia/assets/20028486/2f4a3df8-a7b3-4788-959e-ded800fb65b3)
