### PR TITLE
added options to promotion

### DIFF
--- a/lib/components/base/Promotion.vue
+++ b/lib/components/base/Promotion.vue
@@ -6,7 +6,7 @@
           <a
             href="https://exaroton.com/?utm_source=modrinth&utm_medium=text&utm_campaign=host&utm_content=top"
             rel="noopener nofollow sponsored"
-            target="_blank"
+            :target="target"
           >
             <ExarotonIcon class="MYYLVTXBPUVWMLVBPVSDLHADDRYFBF-3" />
             <span>
@@ -18,13 +18,22 @@
         </div>
       </div>
       <div class="MYYLVTXBPUVWMLVBPVSDLHADDRYFBF-4">
-        <a rel="noopener sponsored" target="_blank" href="https://adrinth.com"> Ads via Adrinth </a>
+        <a rel="noopener sponsored" :target="target" href="https://adrinth.com"> Ads via Adrinth </a>
       </div>
     </div>
   </div>
 </template>
 <script setup>
+import { computed } from 'vue';
 import ExarotonIcon from '@/assets/external/exaroton.svg'
+const props = defineProps({
+  external: {
+    type: Boolean,
+    default: true
+  }
+})
+const target = computed(() => props.external ? '_blank' : '_self')
+
 </script>
 
 <style lang="scss">

--- a/lib/components/base/Promotion.vue
+++ b/lib/components/base/Promotion.vue
@@ -18,22 +18,23 @@
         </div>
       </div>
       <div class="MYYLVTXBPUVWMLVBPVSDLHADDRYFBF-4">
-        <a rel="noopener sponsored" :target="target" href="https://adrinth.com"> Ads via Adrinth </a>
+        <a rel="noopener sponsored" :target="target" href="https://adrinth.com">
+          Ads via Adrinth
+        </a>
       </div>
     </div>
   </div>
 </template>
 <script setup>
-import { computed } from 'vue';
+import { computed } from 'vue'
 import ExarotonIcon from '@/assets/external/exaroton.svg'
 const props = defineProps({
   external: {
     type: Boolean,
-    default: true
-  }
+    default: true,
+  },
 })
-const target = computed(() => props.external ? '_blank' : '_self')
-
+const target = computed(() => (props.external ? '_blank' : '_self'))
 </script>
 
 <style lang="scss">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omorphia",
   "type": "module",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "files": [
     "dist",
     "lib"


### PR DESCRIPTION
Makes the 'new tab' aspect of ads disableable (relevant for use in Tauri, in which case this causes it to open a *second* window)

https://github.com/modrinth/theseus/issues/225