### PR TITLE
Fix clicking edges of clickable elements

### DIFF
--- a/lib/assets/styles/classes.scss
+++ b/lib/assets/styles/classes.scss
@@ -249,6 +249,7 @@ a,
     left: 0;
     right: 0;
     pointer-events: all;
+    border-radius: inherit;
   }
 
   &:active::before {
@@ -414,10 +415,6 @@ a,
     background: none;
     box-shadow: none;
   }
-
-  &::before {
-    border-radius: var(--radius-md);
-  }
 }
 
 .btn-group {
@@ -511,10 +508,6 @@ a,
       color: var(--color-blue);
       text-decoration: underline;
     }
-  }
-
-  &::before {
-    border-radius: var(--radius-lg);
   }
 
   // TODO: Add back later
@@ -714,10 +707,6 @@ a,
 
   &:hover &:focus {
     background: var(--color-button-bg);
-  }
-
-  &::before {
-    border-radius: var(--radius-max);
   }
 }
 

--- a/lib/assets/styles/classes.scss
+++ b/lib/assets/styles/classes.scss
@@ -230,9 +230,29 @@ a,
 .clickable {
   transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, scale 0.05s ease-in-out,
     outline 0.2s ease-in-out;
+    
+  position: relative;
+
+  &:not([rel~=ugc]) {
+    pointer-events: none;
+  }
 
   &:active:not(&:disabled) {
     scale: 0.95;
+  }
+
+  &:not([rel~=ugc])::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    pointer-events: all;
+  }
+
+  &:active::before {
+    scale: 1.1;
   }
 }
 
@@ -394,6 +414,10 @@ a,
     background: none;
     box-shadow: none;
   }
+
+  &::before {
+    border-radius: var(--radius-md);
+  }
 }
 
 .btn-group {
@@ -487,6 +511,10 @@ a,
       color: var(--color-blue);
       text-decoration: underline;
     }
+  }
+
+  &::before {
+    border-radius: var(--radius-lg);
   }
 
   // TODO: Add back later
@@ -686,6 +714,10 @@ a,
 
   &:hover &:focus {
     background: var(--color-button-bg);
+  }
+
+  &::before {
+    border-radius: var(--radius-max);
   }
 }
 

--- a/lib/assets/styles/classes.scss
+++ b/lib/assets/styles/classes.scss
@@ -233,7 +233,7 @@ a,
     
   position: relative;
 
-  &:not([rel~=ugc]) {
+  &:not(.markdown-body a) {
     pointer-events: none;
   }
 
@@ -241,7 +241,7 @@ a,
     scale: 0.95;
   }
 
-  &:not([rel~=ugc])::before {
+  &:not(.markdown-body a)::before {
     content: '';
     position: absolute;
     top: 0;

--- a/lib/assets/styles/classes.scss
+++ b/lib/assets/styles/classes.scss
@@ -230,7 +230,7 @@ a,
 .clickable {
   transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, scale 0.05s ease-in-out,
     outline 0.2s ease-in-out;
-    
+
   position: relative;
 
   &:not(.markdown-body a) {

--- a/lib/components/base/Pagination.vue
+++ b/lib/components/base/Pagination.vue
@@ -152,6 +152,10 @@ a {
     transform: scale(0.95);
     filter: brightness(0.8);
   }
+
+  &::before {
+    border-radius: 2rem;
+  }
 }
 
 .has-icon {

--- a/lib/components/base/Pagination.vue
+++ b/lib/components/base/Pagination.vue
@@ -152,10 +152,6 @@ a {
     transform: scale(0.95);
     filter: brightness(0.8);
   }
-
-  &::before {
-    border-radius: 2rem;
-  }
 }
 
 .has-icon {


### PR DESCRIPTION
Use the `::before` pseudo element to create an invisible overlay over clickable elements that does not shrink. This ensures that clicks on the edges of buttons are registered. 

fixes #86 