### PR TITLE
improve dropdown transitions

### DIFF
--- a/lib/components/base/DropdownButton.vue
+++ b/lib/components/base/DropdownButton.vue
@@ -201,6 +201,12 @@ onBeforeUnmount(() => {
 
     .btn {
       height: 2.25rem;
+
+      transition: 0.05s;
+
+      &:not(.render-down):not(.render-up) {
+        transition-delay: 0.2s;
+      }
     }
   }
 

--- a/lib/components/base/DropdownSelect.vue
+++ b/lib/components/base/DropdownSelect.vue
@@ -210,6 +210,12 @@ const isChildOfDropdown = (element) => {
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-inset-sm), 0 0 0 0 transparent;
 
+    transition: 0.05s;
+
+    &:not(.render-down):not(.render-up) {
+      transition-delay: 0.2s;
+    }
+
     &.disabled {
       cursor: not-allowed;
       filter: grayscale(50%);
@@ -232,6 +238,7 @@ const isChildOfDropdown = (element) => {
 
     .arrow {
       transition: transform 0.2s ease;
+
       &.rotate {
         transform: rotate(180deg);
       }

--- a/lib/components/search/SearchDropdown.vue
+++ b/lib/components/search/SearchDropdown.vue
@@ -316,6 +316,8 @@ const isChildOfDropdown = (element) => {
   box-shadow: var(--shadow-inset-sm), 0 0 0 0 transparent !important;
   width: 100%;
 
+  transition: 0.05s;
+
   &:focus {
     &.down {
       border-radius: var(--radius-md) var(--radius-md) 0 0 !important;
@@ -324,6 +326,10 @@ const isChildOfDropdown = (element) => {
     &.up {
       border-radius: 0 0 var(--radius-md) var(--radius-md) !important;
     }
+  }
+
+  &:not(:focus) {
+    transition-delay: 0.2s;
   }
 }
 </style>


### PR DESCRIPTION
This PR slightly improves the dropdown closing transitions by delaying the rounding of the corners to remove this weird transition state: 
![grafik](https://github.com/modrinth/omorphia/assets/81473300/5afd7bd4-58f3-487f-9c96-fb587c328c03)
