### PR TITLE
fix dropdownButton double event emit

### DIFF
--- a/lib/components/base/DropdownButton.vue
+++ b/lib/components/base/DropdownButton.vue
@@ -278,6 +278,10 @@ onBeforeUnmount(() => {
       input {
         display: none;
       }
+
+      label {
+        pointer-events: none;
+      }
     }
   }
 }


### PR DESCRIPTION
currently when clicking on the text of a dropdownButton

e.g. yellow marked area
![grafik](https://github.com/modrinth/omorphia/assets/81473300/51d29656-3f03-4edc-b40a-58b99002c3fa)

the `option-click` event is emitted twice

I believe this is because you are clicking on the `label` which has its own click action which is canceled and because of that forwarded to the `div` (tbh I don't know just a guess)

I could imagine that this could resolve this [issue](https://github.com/modrinth/theseus/issues/680)