### PR TITLE
add snappingPoints to slider

### DIFF
--- a/docs/components/slider.md
+++ b/docs/components/slider.md
@@ -9,6 +9,7 @@ const valueTwo = ref(0)
 
 <DemoContainer>
   <Slider v-model="value" :min="1000" :max="10000" :step="1000" unit="mb"/>
+  <Slider v-model="value" :min="1024" :max="32768" :step="1" :snapPoints='[2048,4096,8192,16384]' :snapRange='500' unit="mb"/>
   <Slider v-model="valueTwo" :min="1000" :max="10000" :step="1000" unit="mb" :disabled="true"/>
 </DemoContainer>
 


### PR DESCRIPTION
This PR adds the option to add snapping points to a slider

snapping points make it easier to set exact values while still allowing arbitrary values

![grafik](https://github.com/modrinth/omorphia/assets/81473300/17157857-005c-416e-9f2d-cad6f4a0817c)

this could be used for e.g. setting the Java memory in Theseus


note:
is there a reason why no nested CSS is used even though scss is enabled?