### PR TITLE
fix Markdown table corners

### DIFF
--- a/lib/assets/styles/classes.scss
+++ b/lib/assets/styles/classes.scss
@@ -946,7 +946,7 @@ a,
     border-collapse: separate;
     border-spacing: 0;
     line-height: 1.5;
-    border: 0.05rem solid var(--color-button-bg);
+    border: 0.1rem solid var(--color-button-bg);
     border-radius: var(--radius-sm);
 
     th {
@@ -956,27 +956,18 @@ a,
     td,
     th {
       padding: 0.4rem 0.85rem;
-      border: 0.05rem solid var(--color-button-bg);
     }
 
     tr:nth-child(2n) {
       background-color: var(--color-accent-contrast);
     }
 
-    th:first-of-type {
-      border-top-left-radius: var(--radius-sm);
+    td:not(:last-of-type), th:not(:last-of-type) {
+      border-right: 0.1rem solid var(--color-button-bg);
     }
 
-    th:last-of-type {
-      border-top-right-radius: var(--radius-sm);
-    }
-
-    tr:last-of-type td:first-of-type {
-      border-bottom-left-radius: var(--radius-sm);
-    }
-
-    tr:last-of-type td:last-of-type {
-      border-bottom-right-radius: var(--radius-sm);
+    tr:not(:last-of-type) td, th {
+      border-bottom: 0.1rem solid var(--color-button-bg);
     }
   }
 


### PR DESCRIPTION
This Pr [resolves](https://github.com/modrinth/knossos/issues/1412)

simply changing the inner border so the radius fits the outer did not work perfectly
![grafik](https://github.com/modrinth/omorphia/assets/81473300/1e8e7067-6827-421c-a3f5-9ac77af7f265)

this should work as long as the table can only have one header row which should be true for any markdown table