### PR TITLE
Fix ambiguous default export

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,6 +1,6 @@
 import { localeDefinitions } from '@modrinth/omorphia-dev/locales/index.js'
 import { createPlugin } from '@vintl/vintl/plugin'
-import Omorphia from 'omorphia'
+import { plugin as Omorphia } from 'omorphia'
 import DefaultTheme from 'vitepress/theme'
 import { createVNode } from 'vue'
 import DemoContainer from './DemoContainer.vue'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,14 +2,13 @@ import * as components from './components/index.js'
 import FloatingVue from 'floating-vue'
 import { Plugin } from 'vue'
 
-const plugin: Plugin = (app) => {
+export const plugin: Plugin = (app) => {
   for (const key in components) {
     app.component(key, components[key as keyof typeof components])
   }
   app.use(FloatingVue)
 }
 
-export default plugin
 export * from './components/index.js'
 export * from './helpers/index.js'
 


### PR DESCRIPTION
Currently Omorphia's index file has both the default and named exports. While this is totally supported by native ESM, it's pretty hard for transpilers to process and may lead to situations where named exports cannot be imported directly, requiring destructuring on the default import. For this and just consistency reasons, you'd usually avoid mixing default and named exports.

This PR removes the default export, making it just an another named export called `plugin`.

BREAKING CHANGE: plugin is now exported using `plugin` export, rather than the default export.
