### PR TITLE
Make Omorphia an ESM-only module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,11 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/omorphia.umd.cjs",
   "module": "./dist/omorphia.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/omorphia.js",
-      "require": "./dist/omorphia.cjs"
+      "import": "./dist/omorphia.js"
     },
     "./dist/style.css": "./dist/style.css"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'lib/index.ts'),
       name: 'Omorphia',
       fileName: 'omorphia',
-      formats: ['es', 'cjs'],
+      formats: ['es'],
     },
   },
   plugins: [


### PR DESCRIPTION
ESM is widely supported these days and continues to improve. All
intended Omorphia consumers do not use CJS export, as such it is
unnecessary and can be safely removed to speed up the build process
and remove the possibility of the dual package hazard.

Third-party consumers recommended to switch to ESM or use async import.

Recommended read:
https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
