### PR TITLE
remove up/down arrows in number inputs for firefox

### DIFF
--- a/lib/assets/styles/defaults.scss
+++ b/lib/assets/styles/defaults.scss
@@ -88,6 +88,7 @@ textarea,
 }
 
 input[type='number'] {
+  -moz-appearance: textfield !important;
   &::-webkit-inner-spin-button,
   &::-webkit-outer-spin-button {
     -webkit-appearance: none;


### PR DESCRIPTION
I think the title says it all

currently, it looks like this:
![grafik](https://github.com/modrinth/omorphia/assets/81473300/f08fa00c-cc0d-41a3-b14c-2048d505388b)
