### PR TITLE
Enable allowSyntheticDefaultImports in TS config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
WebStorm seems to have problems if this option is missing from tsconfig.
While still uncertain whether or not WebStorm is correct (VS Code with
TypeScript LS doesn't have this issue), enabling it doesn't seem to
cause any problems.
