### PR TITLE
allow simple arithmetic in slider input field

### DIFF
--- a/lib/components/base/Slider.vue
+++ b/lib/components/base/Slider.vue
@@ -108,8 +108,22 @@ const onInputWithSnap = (value: string) => {
   inputValueValid(parsedValue)
 }
 
+const parseExpression = (value: string) => {
+  let tokens = value.match(/^\s*(\d+)\s*(\+|-|\*|\/)\s*(\d+)\s*$/)
+  if (tokens !== null) {
+    let [, a, op, b] = tokens
+
+    if (op === '+') return parseInt(a) + parseInt(b)
+    if (op === '-') return parseInt(a) - parseInt(b)
+    if (op === '*') return parseInt(a) * parseInt(b)
+    if (op === '/') return parseInt(a) / parseInt(b)
+  }
+
+  return parseInt(value)
+}
+
 const onInput = (value: string) => {
-  inputValueValid(parseInt(value))
+  inputValueValid(parseExpression(value))
 }
 </script>
 


### PR DESCRIPTION
implements a simple form of https://github.com/modrinth/theseus/issues/720

https://github.com/modrinth/omorphia/assets/22177966/5a4a1e34-41d8-4dc7-9c5d-b1c29933cc44

This only allows simple math in the form of `50+2`, no multiple operators, parenthesis, or "8gb + 10mb" symbols, but I wanted to open this PR first to check if there's even interest in merging this.

---

ChatGPT suggested this alternative implementation which would implement parenthesis etc. nicely but I don't know if that's worth the use of the dubious `eval` function.
```js
let sanitizedExpression = expression.replace(/[^0-9+\-*/().]/g, ''); // Sanitize input
let result = eval(sanitizedExpression); // Use eval on sanitized input
```