### PR TITLE
Add margin-top to DemoContainer

### DIFF
--- a/docs/.vitepress/theme/DemoContainer.vue
+++ b/docs/.vitepress/theme/DemoContainer.vue
@@ -12,5 +12,6 @@
   align-items: center;
   flex-wrap: wrap;
   border-radius: var(--radius-lg);
+  margin-top: 1em;
 }
 </style>


### PR DESCRIPTION
Adds `margin-top: 1em;` to DemoContainer

## Before

![before](https://github.com/modrinth/omorphia/assets/43351072/065fdedb-adc2-41aa-93e9-4993843daf81)

## After

![after](https://github.com/modrinth/omorphia/assets/43351072/f249762d-62ab-4af6-b718-af77cd24c647)
