### PR TITLE
Add align to img, p, and div

### DIFF
--- a/lib/helpers/parse.js
+++ b/lib/helpers/parse.js
@@ -14,7 +14,7 @@ export const configuredXss = new xss.FilterXSS({
     kbd: ['id'],
     input: ['checked', 'disabled', 'type'],
     iframe: ['width', 'height', 'allowfullscreen', 'frameborder', 'start', 'end'],
-    img: [...xss.whiteList.img, 'usemap', 'style'],
+    img: [...xss.whiteList.img, 'usemap', 'style', 'align'],
     map: ['name'],
     area: [...xss.whiteList.a, 'coords'],
     a: [...xss.whiteList.a, 'rel'],
@@ -22,6 +22,8 @@ export const configuredXss = new xss.FilterXSS({
     th: [...xss.whiteList.th, 'style'],
     picture: [],
     source: ['media', 'sizes', 'src', 'srcset', 'type'],
+    p: [...xss.whiteList.p, 'align'],
+    div: [...xss.whiteList.p, 'align'],
   },
   css: {
     whiteList: {


### PR DESCRIPTION
Supersedes [knossos#1401](https://github.com/modrinth/knossos/pull/1401) which fixes [knossos#1207](https://github.com/modrinth/knossos/issues/1207) but also adds it to p and div for better Github Markdown compatibility.

In the knossos PR, I had to add `overflow:y` to `.markdown-body`, however at least when testing in omorphia's docs page, no css change was needed